### PR TITLE
fix(nhl): collapse api-web place/common token doubling in team names

### DIFF
--- a/R/nhl_schedule.R
+++ b/R/nhl_schedule.R
@@ -286,7 +286,17 @@ nhl_schedule <- function(day = NULL, season = NULL, team_abbr = NULL,
     if (is.null(common)) return(as.character(place))
     # ifelse() here is element-wise over the per-row `common` vector (correct
     # use); paste()/trimws() are vectorized, so length is preserved.
-    trimws(paste(place, ifelse(is.na(common), "", common)))
+    joined <- trimws(paste(place, ifelse(is.na(common), "", common)))
+    # api-web overlaps place/common inconsistently across seasons, doubling a
+    # token both ways: "NY Rangers" + "Rangers" -> "NY Rangers Rangers", and
+    # "Utah" + "Utah Hockey Club" -> "Utah Utah Hockey Club". Collapse adjacent
+    # duplicate words so the full name stays canonical either way.
+    vapply(joined, function(s) {
+        if (is.na(s)) return(NA_character_)
+        w <- strsplit(s, " ", fixed = TRUE)[[1]]
+        if (length(w) < 2) return(s)
+        paste(w[c(TRUE, w[-1] != w[-length(w)])], collapse = " ")
+    }, character(1), USE.NAMES = FALSE)
 }
 
 

--- a/tests/testthat/test-nhl_schedule.R
+++ b/tests/testthat/test-nhl_schedule.R
@@ -284,3 +284,20 @@ test_that(".nhl_full_team_name: falls back to place name when common is absent",
     # No place name at all -> scalar NA (whole column is missing).
     expect_equal(fastRhockey:::.nhl_full_team_name(list()), NA_character_)
 })
+
+
+test_that(".nhl_full_team_name: collapses api-web's inconsistent token doubling", {
+    # api-web overlaps place/common inconsistently across seasons: placeName can
+    # trail into the common name ("NY Rangers" + "Rangers") and commonName can
+    # lead with the place ("Utah" + "Utah Hockey Club"). Both must de-double.
+    team <- list(
+        placeName = data.frame(
+            default = c("NY Rangers", "Utah", "New York"), stringsAsFactors = FALSE),
+        commonName = data.frame(
+            default = c("Rangers", "Utah Hockey Club", "Rangers"), stringsAsFactors = FALSE)
+    )
+    expect_equal(
+        fastRhockey:::.nhl_full_team_name(team),
+        c("NY Rangers", "Utah Hockey Club", "New York Rangers")
+    )
+})


### PR DESCRIPTION
Follow-up to #63. api-web populates `placeName`/`commonName` inconsistently across seasons, so the place+common join in `.nhl_full_team_name()` doubles a token **both** ways:

- `placeName` "NY Rangers" + `commonName` "Rangers" → "NY Rangers Rangers" (place trails into common)
- `placeName` "Utah" + `commonName` "Utah Hockey Club" → "Utah Utah Hockey Club" (common leads with place)

Both appear in real historical data (NYR in a minority of 2021-22 games; UTA throughout 2024-25). This collapses adjacent duplicate words so the full name stays canonical in either case.

## Tests
New `.nhl_full_team_name` case covering both doubling patterns plus the clean "New York" + "Rangers" → "New York Rangers" control. Offline tests green (R 4.5.3); docs regenerated.

Surfaced while republishing the `nhl_schedules` release — the release itself is already patched clean; this fixes the source so future scrapes stay correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NHL team name handling when API data is incomplete or inconsistent.
  * Prevented duplicated words in displayed team names.

* **Tests**
  * Added coverage for missing team names, partial data, and duplicate-name scenarios.

* **Documentation**
  * Added documentation for the team name handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->